### PR TITLE
remove global aws config update and move to the s3 constructor

### DIFF
--- a/lib/feature-manager.js
+++ b/lib/feature-manager.js
@@ -5,7 +5,7 @@ var extend = require('extend'),
 
 var defaultConfig = {
 	sourceType: 'local',		// one of ['local','http','s3']
-	sourcePath:'features.json',	// must have one of [sourcePath, sourceUrl, sourceBucket && sourcePath]
+	sourcePath: 'features.json',	// must have one of [sourcePath, sourceUrl, sourceBucket && sourcePath]
 	ttl: 86400					// in s, default 1 day
 };
 
@@ -17,18 +17,18 @@ var ENUMS = {
 	}
 };
 
-var readFileFromLocal = function(cfg) {
+var readFileFromLocal = function (cfg) {
 	return Q.nfapply(FS.readFile, [cfg.sourcePath, 'utf-8']);
 };
 
-var readFileFromHttp = function(cfg) {
+var readFileFromHttp = function (cfg) {
 	return Q.reject('not supported yet');
 };
 
-var readFileFromS3 = function(cfg) {
+var readFileFromS3 = function (cfg) {
 	var deferred = Q.defer();
-	var s3 = new AWS.S3();
-	s3.getObject({Bucket: cfg.sourceBucket, Key: cfg.sourcePath}, function(err,response) {
+	var s3 = new AWS.S3(cfg.aws);
+	s3.getObject({ Bucket: cfg.sourceBucket, Key: cfg.sourcePath }, function (err, response) {
 		if (err) {
 			deferred.reject(err);
 		} else {
@@ -38,11 +38,11 @@ var readFileFromS3 = function(cfg) {
 	return deferred.promise;
 };
 
-var cacheExpired = function(ctx) {
+var cacheExpired = function (ctx) {
 	return ctx.expires < new Date().getTime();
 };
 
-var updateSource = function(ctx,force) {
+var updateSource = function (ctx, force) {
 	var deferred = Q.defer();
 	// only update if we are forcing or the TTL has expired
 	if (ctx.updating) {
@@ -62,7 +62,7 @@ var updateSource = function(ctx,force) {
 				break;
 		}
 		strategyMethod(ctx.config).then(
-			function(featureString) {
+			function (featureString) {
 				try {
 					var featureObject = JSON.parse(featureString);
 					ctx.featureList = featureObject;
@@ -77,59 +77,62 @@ var updateSource = function(ctx,force) {
 					ctx.updating = false;
 				}
 			},
-			function(reason) { deferred.reject(reason); ctx.updating = false; });
+			function (reason) { deferred.reject(reason); ctx.updating = false; });
 	} else {
 		deferred.resolve(ctx.featureList);
 	}
 	return deferred.promise;
 };
 
-var FeatureManager = function(_config) {
+var FeatureManager = function (_config) {
 	this.config = JSON.parse(JSON.stringify(defaultConfig));
-	extend(this.config,_config);
+	extend(this.config, _config);
 	this.expires = 0;
 	this.featureList = {};
-	if (this.config.sourceType === ENUMS.SourceType.S3) {
-		AWS.config.update(this.config.aws);
-	}
+
+	// IMPORTANT: do not set the global aws creds config here to allow services to pull
+	// from multiple s3 accounts
+	// if (this.config.sourceType === ENUMS.SourceType.S3) {
+	// 	   AWS.config.update(this.config.aws);
+	// }
 	this.updating = false;
 };
 
 FeatureManager.SourceType = ENUMS.SourceType;
 
-FeatureManager.prototype.getConfig = function() {
+FeatureManager.prototype.getConfig = function () {
 	return this.config;
 };
 
-FeatureManager.prototype.getFeatureList = function(forceUpdate) {
-	return updateSource(this,forceUpdate).then(function(result) {
+FeatureManager.prototype.getFeatureList = function (forceUpdate) {
+	return updateSource(this, forceUpdate).then(function (result) {
 		return Q(result);
-	}, function(reason) {
+	}, function (reason) {
 		return Q.reject(reason);
 	});
 };
 
-FeatureManager.prototype.isEnabled = function(featureId) {
-	return updateSource(this).then(function() {
+FeatureManager.prototype.isEnabled = function (featureId) {
+	return updateSource(this).then(function () {
 		return Q(this.isEnabledSync(featureId));
 	});
 };
 
-FeatureManager.prototype.getFeatureOptions = function(featureId) {
-	return updateSource(this).then(function() {
+FeatureManager.prototype.getFeatureOptions = function (featureId) {
+	return updateSource(this).then(function () {
 		return Q(this.featureList[featureId] ? this.featureList[featureId] : null);
 	});
 };
 
-FeatureManager.prototype.getFeatureOption = function(featureId,optionKey) {
-	return updateSource(this).then(function() {
+FeatureManager.prototype.getFeatureOption = function (featureId, optionKey) {
+	return updateSource(this).then(function () {
 		return Q(this.isEnabledSync(featureId));
 	});
 };
 
 
-FeatureManager.prototype.isEnabledSync = function(featureId) {
-	if (!this.featureList || cacheExpired(this) ) {
+FeatureManager.prototype.isEnabledSync = function (featureId) {
+	if (!this.featureList || cacheExpired(this)) {
 		throw { name: 'FeatureManagerException', message: 'Unable to synchronously check for feature; featureList has not been initialized' };
 	}
 	var featureItem = this.featureList[featureId];

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,293 @@
+{
+  "name": "feature-manager",
+  "version": "0.2.1-alyssatest1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "aws-sdk": {
+      "version": "2.554.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.554.0.tgz",
+      "integrity": "sha512-23EQhz4pCRwzCRRc40deQgoO2ddCT4ylfoVPAuQKOQA8SZqMCWYGkntHjtNWVMd5zIJzHYt26qo8s8zsorc7Rg==",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.13",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      }
+    },
+    "base64-js": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+      "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
+      }
+    },
+    "commander": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+      "dev": true,
+      "requires": {
+        "ms": "0.7.1"
+      }
+    },
+    "diff": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
+      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
+      "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+      "dev": true
+    },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
+    "extend": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.2.tgz",
+      "integrity": "sha512-AgFD4VU+lVLP6vjnlNfF7OeInLTyeyckCNPEsuxz1vi786UuK/nk6ynPuhn/h+Ju9++TQyr5EpLRI14fc1QtTQ=="
+    },
+    "glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+      "dev": true,
+      "requires": {
+        "inherits": "2",
+        "minimatch": "0.3"
+      }
+    },
+    "growl": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
+      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "dev": true
+    },
+    "ieee754": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+      "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "jade": {
+      "version": "0.26.3",
+      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
+      "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
+          "dev": true
+        }
+      }
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "lru-cache": {
+      "version": "2.7.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
+      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+      "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+      "dev": true,
+      "requires": {
+        "lru-cache": "2",
+        "sigmund": "~1.0.0"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "mocha": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.11",
+        "growl": "1.9.2",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.1",
+        "supports-color": "1.2.0",
+        "to-iso-string": "0.0.2"
+      }
+    },
+    "ms": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+      "dev": true
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+    },
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+    },
+    "should": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/should/-/should-5.2.0.tgz",
+      "integrity": "sha1-mkUZtEe4te7c6e7ZavNCDUUaVAs=",
+      "dev": true,
+      "requires": {
+        "should-equal": "0.3.1",
+        "should-format": "0.0.7",
+        "should-type": "0.0.4"
+      }
+    },
+    "should-equal": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/should-equal/-/should-equal-0.3.1.tgz",
+      "integrity": "sha1-vY6pemdI45+tR2o75v1y68LnK/A=",
+      "dev": true,
+      "requires": {
+        "should-type": "0.0.4"
+      }
+    },
+    "should-format": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/should-format/-/should-format-0.0.7.tgz",
+      "integrity": "sha1-Hi74a9kdqcLgQSM1tWq6vZov3hI=",
+      "dev": true,
+      "requires": {
+        "should-type": "0.0.4"
+      }
+    },
+    "should-type": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/should-type/-/should-type-0.0.4.tgz",
+      "integrity": "sha1-ATKgVBemEmhmQmrPEW8e1WI6XNA=",
+      "dev": true
+    },
+    "sigmund": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
+      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
+      "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
+      "dev": true
+    },
+    "to-iso-string": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
+      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
+      "dev": true
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "feature-manager",
   "description": "Feature flag manager for SaaS and white-label products",
   "author": "Nafis Zebarjadi <nafis@medicast.co>",
-  "version": "0.3.0",
+  "version": "1.0.0",
   "maintainers": [
     "Nafis Zebarjadi <nafis@medicast.co> (https://www.medicast.com)"
   ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "feature-manager",
   "description": "Feature flag manager for SaaS and white-label products",
   "author": "Nafis Zebarjadi <nafis@medicast.co>",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "maintainers": [
     "Nafis Zebarjadi <nafis@medicast.co> (https://www.medicast.com)"
   ],


### PR DESCRIPTION
Setting the global aws config will cause all aws imports to use those credentials.  

I am trying to pull from s3 in a different aws account in the dispatch service.

In some cases, the S3 constructor can override the global by passing in creds, but since the kube2iam method we use does not expose credential values to the service and instead authenticates api requests, I was unable to find a way to override the global higher up in the service layer.